### PR TITLE
Fix container name for continuous deployment

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -37,7 +37,7 @@ phases:
       - docker push $ECR_REPOSITORY_URI:$IMAGE_VERSION
       - docker push $ECR_REPOSITORY_URI:$IMAGE_TAG
       - echo Writing image definitions file...
-      - printf '[{"name":"website","imageUri":"%s"}]' $ECR_REPOSITORY_URI:$IMAGE_VERSION > imagedefinitions.json
+      - printf '[{"name":"website-container","imageUri":"%s"}]' $ECR_REPOSITORY_URI:$IMAGE_VERSION > imagedefinitions.json
 artifacts:
   files:
     - imagedefinitions.json


### PR DESCRIPTION
The `name` in the following line references the container name of our service in ECS.
```
printf '[{"name":"website-container","imageUri":"%s"}]' $ECR_REPOSITORY_URI:$IMAGE_VERSION > imagedefinitions.json
```

The value of that name was wrong.
This PR fixes it to make it match with the container name define in ECS.
