### PR TITLE
Use Django 3.1 to get improvements and bug fixes

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,7 +2,7 @@ version: 0.2
 
 env:
   variables:
-     IMAGE_VERSION: "1.0.27"
+     IMAGE_VERSION: "1.0.28"
      ECR_REPOSITORY_URI: "476954489154.dkr.ecr.us-east-1.amazonaws.com/website"
      AWS_DEFAULT_REGION: "us-east-1"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 asgiref==3.2.3
 astroid==2.3.3
 autopep8==1.5
-Django==3.0.2
+Django==3.1
 isort==4.3.21
 lazy-object-proxy==1.4.3
 Markdown==3.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-asgiref==3.2.3
+asgiref==3.2.10
 astroid==2.3.3
 autopep8==1.5
 Django==3.1


### PR DESCRIPTION
Main changes:
1. Use Django 3.1 to get improvements and bug fixes
1. Update dependency required by Django