### PR TITLE
Remove horizontal overflow in website

### DIFF
--- a/blog/posts/solving-a-hackerrank-problem-using-haskell.md
+++ b/blog/posts/solving-a-hackerrank-problem-using-haskell.md
@@ -9,7 +9,7 @@ tags: haskell
 
 # Solving a HackerRank problem using Haskell
 
-2018-09-22
+2018-09-22, last updated 2020-09-05
 
 I have been learning Haskell with this great book: [Learn You a Haskell for Great Good!](http://learnyouahaskell.com/)<br>
 When I learn something new, I split the learning process in two parts:
@@ -60,13 +60,11 @@ getIntSquareMatrix rows = do
 The function `getIntSquareMatrix` receives an `Int` as paramenter and returns a matrix of Int elements, inside an IO "wrapper" `IO([[Int]])`. Allow me to explain this function line by line:
 
 Line 6 reads a line from stdin N times, where N is defined by the parameter `rows`, then it binds the result to `lines`.
+The type of `lines` is `[String]`. Why?
 
-What is the type of `lines`?
-
->`lines <- replicateM rows getLine` returns a type `IO([String])`<br>
-> so `lines <- IO([String])`<br>
-> Left arrow `<-` binds the `[String]` contained in the `IO` "wrapper" to `lines`<br>
-> Then `lines` is of type `[String]`
+1. `replicateM rows getLine` returns an `IO([String])`
+2. `<-` binds the `[String]` from `IO([String])` to `lines`
+3. Therefore `lines` is of type `[String]`
 
 Line 7 applies some functions to `lines` and defines `intMatrix` of type `[[Int]]`.
 

--- a/blog/static/blog/css/blog.css
+++ b/blog/static/blog/css/blog.css
@@ -10,6 +10,16 @@
     font-size: .875em;
 }
 
+@media only screen and (max-width: 1024px) {
+    .highlighttable {
+        font-size: .875em;
+        display: block;
+        overflow-x: auto;
+        white-space: nowrap;
+        margin-bottom: 1.5rem
+    }
+}
+
 table.highlighttable td {
     padding: 0;
 }

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,7 +2,7 @@ version: 0.2
 
 env:
   variables:
-     IMAGE_VERSION: "1.0.28"
+     IMAGE_VERSION: "1.0.29"
      ECR_REPOSITORY_URI: "476954489154.dkr.ecr.us-east-1.amazonaws.com/website"
      AWS_DEFAULT_REGION: "us-east-1"
 

--- a/static/css/website.css
+++ b/static/css/website.css
@@ -2,7 +2,7 @@
     display: flex;
     min-height: 100vh;
     flex-direction: column;
-    overflow-x: scroll;
+    overflow-x: hidden;
 }
 
 .site-content {

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link rel="preload" href="https://cdn.jsdelivr.net/npm/bulma@0.8.0/css/bulma.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.8.0/css/bulma.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.8.0/css/bulma.min.css"></noscript>
 
     {% include "analytics.html" %}


### PR DESCRIPTION
Main changes:
1. Improve explanation of variable type
1. Show scroll in code fragments on mobile devices
1. Do not allow horizontal scroll on the website
1. Declare `rel` as `stylesheet` because Firefox does not support `preload` yet

Closes #62 